### PR TITLE
Reduce DataGrid refresh loops

### DIFF
--- a/Formularios/main.vb
+++ b/Formularios/main.vb
@@ -180,6 +180,40 @@ Public Partial Class main
         End If
     End Sub
 
+    Private Sub aplicarEstilosDG()
+        If tabla = "autos" Then
+            autosConDeudaDG(dgv_main, Color.Red)
+        ElseIf tabla = "items" Then
+            resaltarcolumnaDG(dgv_main, lightItemCol, Color.Red)
+            pintaStockItemsDG(dgv_main, clrMinimo)
+        ElseIf tabla = "items_full" Then
+            resaltarcolumnaDG(dgv_main, lightItemCol, Color.Red)
+        ElseIf tabla = "archivoConsultas" Then
+            dgv_main.Columns(0).Width = 50
+        ElseIf tabla = "registros_stock" Then
+            resaltarcolumnaDG(dgv_main, lightRegStock, Color.Red)
+        ElseIf tabla = "pedidos" Then
+            If activo Then
+                resaltarcolumnaDG(dgv_main, 5, Color.Red)
+            Else
+                resaltarcolumnaDG(dgv_main, 6, Color.Red)
+            End If
+        ElseIf tabla = "pedidos_hoy" Then
+            resaltarcolumnaDG(dgv_main, 6, Color.Red)
+            resaltarPedidosInactivosDG(dgv_main, Color.Red)
+        ElseIf tabla = "casos" Or tabla = "casos_hoy" Then
+            If activo Then
+                resaltarcolumnaDG(dgv_main, 5, Color.Red)
+            Else
+                resaltarcolumnaDG(dgv_main, 6, Color.Red)
+            End If
+            casosConDeudaDG(dgv_main, Color.Red)
+        End If
+
+        dgv_main.AutoResizeColumns(DataGridViewAutoSizeColumnsMode.ColumnHeader)
+        dgv_main.Refresh()
+    End Sub
+
     Private Sub actualizarlsv()
         Dim sqlstr As String = ""
         'chk_stock0.Visible = False
@@ -531,36 +565,7 @@ Public Partial Class main
             tPaginas = Math.Ceiling(nRegs / itXPage)
             txt_nPage.Text = pagina & " / " & tPaginas
 
-            If tabla = "autos" Then
-                autosConDeudaDG(dgv_main, Color.Red)
-            ElseIf tabla = "items" Then
-                resaltarcolumnaDG(dgv_main, lightItemCol, Color.Red)
-                pintaStockItemsDG(dgv_main, clrMinimo)
-            ElseIf tabla = "items_full" Then
-                resaltarcolumnaDG(dgv_main, lightItemCol, Color.Red)
-            ElseIf tabla = "archivoConsultas" Then
-                dgv_main.Columns(0).Width = 50
-            ElseIf tabla = "registros_stock" Then
-                resaltarcolumnaDG(dgv_main, lightRegStock, Color.Red)
-            ElseIf tabla = "pedidos" Then
-                If activo Then
-                    resaltarcolumnaDG(dgv_main, 5, Color.Red)
-                Else
-                    resaltarcolumnaDG(dgv_main, 6, Color.Red)
-                End If
-            ElseIf tabla = "pedidos_hoy" Then
-                resaltarcolumnaDG(dgv_main, 6, Color.Red)
-                resaltarPedidosInactivosDG(dgv_main, Color.Red)
-            ElseIf tabla = "casos" Or tabla = "casos_hoy" Then
-                If activo Then
-                    resaltarcolumnaDG(dgv_main, 5, Color.Red)
-                Else
-                    resaltarcolumnaDG(dgv_main, 6, Color.Red)
-                End If
-                casosConDeudaDG(dgv_main, Color.Red)
-                'dgv_main.Columns(13).Width = 0
-                'dgv_main.Columns(14).Width = 0
-            End If
+            aplicarEstilosDG()
         End If
     End Sub
 
@@ -577,35 +582,7 @@ Public Partial Class main
             tPaginas = Math.Ceiling(nRegs / itXPage)
             txt_nPage.Text = pagina & " / " & tPaginas
 
-            If tabla = "autos" Then
-                autosConDeudaDG(dgv_main, Color.Red)
-            ElseIf tabla = "items" Then
-                resaltarcolumnaDG(dgv_main, lightItemCol, Color.Red)
-                pintaStockItemsDG(dgv_main, clrMinimo)
-            ElseIf tabla = "items_full" Then
-                resaltarcolumnaDG(dgv_main, lightItemCol, Color.Red)
-            ElseIf tabla = "archivoConsultas" Then
-                dgv_main.Columns(0).Width = 50
-            ElseIf tabla = "registros_stock" Then
-                resaltarcolumnaDG(dgv_main, lightRegStock, Color.Red)
-            ElseIf tabla = "pedidos" Then
-                If activo Then
-                    resaltarcolumnaDG(dgv_main, 5, Color.Red)
-                Else
-                    resaltarcolumnaDG(dgv_main, 6, Color.Red)
-                End If
-            ElseIf tabla = "pedidos_hoy" Then
-                resaltarcolumnaDG(dgv_main, 6, Color.Red)
-                resaltarPedidosInactivosDG(dgv_main, Color.Red)
-            ElseIf tabla = "casos" Or tabla = "casos_hoy" Then
-                If activo Then
-                    resaltarcolumnaDG(dgv_main, 5, Color.Red)
-                Else
-                    resaltarcolumnaDG(dgv_main, 6, Color.Red)
-                End If
-                casosConDeudaDG(dgv_main, Color.Red)
-                'dgv_main.Columns(13).Width = 0
-                'dgv_main.Columns(14).Width = 0
+            aplicarEstilosDG()
             End If
         End If
     End Sub

--- a/funciones/autos.vb
+++ b/funciones/autos.vb
@@ -147,8 +147,6 @@ Module autos
                 row.Cells(0).Style.Font = New Font(dg.Font, FontStyle.Bold)
             End If
         Next
-        dg.AutoResizeColumns(DataGridViewAutoSizeColumnsMode.ColumnHeader)
-        dg.Refresh()
     End Sub
 
     Public Function existeAuto(ByVal p As String) As Integer

--- a/funciones/casos.vb
+++ b/funciones/casos.vb
@@ -112,8 +112,6 @@ Module casos
                 row.Cells(0).Style.Font = New Font(dg.Font, FontStyle.Bold)
             End If
         Next
-        dg.AutoResizeColumns(DataGridViewAutoSizeColumnsMode.ColumnHeader)
-        dg.Refresh()
     End Sub
 
     Public Function duplicarCaso(ByVal id As Integer) As Boolean

--- a/funciones/generales.vb
+++ b/funciones/generales.vb
@@ -435,8 +435,6 @@ Module generales
             row.Cells(col).Style.ForeColor = clr
             row.Cells(col).Style.Font = New Font(dg.Font, FontStyle.Bold)
         Next
-        dg.AutoResizeColumns(DataGridViewAutoSizeColumnsMode.ColumnHeader)
-        dg.Refresh()
     End Sub
 
     Public Function sqlstrbuscar(ByVal txtsearch As String) As String

--- a/funciones/items.vb
+++ b/funciones/items.vb
@@ -374,8 +374,6 @@ Module mitem
                 row.Cells(0).Style.Font = New Font(dg.Font, FontStyle.Bold)
             End If
         Next
-        dg.AutoResizeColumns(DataGridViewAutoSizeColumnsMode.ColumnHeader)
-        dg.Refresh()
     End Sub
 
     Public Function infoItem_lastItem() As item

--- a/funciones/pedidos.vb
+++ b/funciones/pedidos.vb
@@ -588,8 +588,6 @@ Module pedidos
                 row.Cells(0).Style.Font = New Font(dg.Font, FontStyle.Bold)
             End If
         Next
-        dg.AutoResizeColumns(DataGridViewAutoSizeColumnsMode.ColumnHeader)
-        dg.Refresh()
     End Sub
 
     Public Sub resaltarCasosInactivos(ByVal lsview As ListView, ByVal clr As Color)
@@ -612,8 +610,6 @@ Module pedidos
                 row.Cells(0).Style.Font = New Font(dg.Font, FontStyle.Bold)
             End If
         Next
-        dg.AutoResizeColumns(DataGridViewAutoSizeColumnsMode.ColumnHeader)
-        dg.Refresh()
     End Sub
 
     Public Function idremitoAsociado(ByVal id_pedido As String) As Integer


### PR DESCRIPTION
## Summary
- add `aplicarEstilosDG` to centralize DataGrid formatting
- call `aplicarEstilosDG` when loading data
- remove repeated AutoResize operations from helper functions

## Testing
- `msbuild /version` *(fails: command not found)*
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68785d6fb2d48323bfdc33017c783acf